### PR TITLE
 Add socket.TCP_NODELAY to the cassandra_cql backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0+dd.13
+
+The cassandra_cql backend uses socket.TCP_NODELAY.
+
 # 0.2.0+dd.12
 
 The cassandra_cql backend no longer uses quorum consistency level for reads and writes. We're concerned about the performance impact and don't think we actually need this guarantee.

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -127,6 +127,10 @@ class _CassandraBackedDict(object):
                 DCAwareRoundRobinPolicy(local_dc=params['datacenter']))
         cluster_params['default_retry_policy'] = RetryPolicy()
 
+        cluster_params['sockopts'] = [
+            (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        ]
+
         log.info(
             "Connecting to cassandra cluster with params %s",
             cluster_params)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.2.0+dd.12'
+version = '0.2.0+dd.13'
 
 TESTS_REQUIRE = ['nose']
 


### PR DESCRIPTION
I want to see if this'll help our latency spikes.