### PR TITLE
[cassandra] optionally wrap connections in ddtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0+dd.17
+
+Add an option to `CassandraCqlManager` to trace queries with [ddtrace](https://github.com/Datadog/dd-trace-py)
+
 # 0.2.0+dd.16
 
 Fix cassandra_cql missing value handling.

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -111,7 +111,6 @@ class _CassandraBackedDict(object):
 
         self._tries = int(params.pop('tries', 1))
 
-        # Use a ddtrace-d connection if instructed to
         cluster = self.__connect_to_cluster(url, params, ddtrace=ddtrace)
         self.__session = cluster.connect(self.__keyspace_cql_safe)
         self.__ensure_table()

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -12,6 +12,9 @@ from beaker_extensions.nosql import Container
 from beaker_extensions.nosql import NoSqlManager
 from beaker_extensions.nosql import pickle
 
+from ddtrace import tracer
+from ddtrace.contrib.cassandra import get_traced_cassandra
+
 try:
     import cassandra
     from cassandra.cluster import Cluster
@@ -45,7 +48,7 @@ class CassandraCqlManager(NoSqlManager):
     connection_pools = {}
 
     def __init__(self, namespace, url=None, data_dir=None, lock_dir=None,
-                 keyspace=None, column_family=None, **params):
+                 keyspace=None, column_family=None, trace=False, **params):
         NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir,
                               lock_dir=lock_dir, **params)
         connection_key = '-'.join([
@@ -57,7 +60,7 @@ class CassandraCqlManager(NoSqlManager):
             self.db_conn = self.connection_pools[connection_key]
         else:
             self.db_conn = _CassandraBackedDict(namespace, url, keyspace,
-                                                column_family, **params)
+                                                column_family, trace, **params)
             self.connection_pools[connection_key] = self.db_conn
 
     def open_connection(self, host, port, **params):
@@ -88,7 +91,7 @@ class _CassandraBackedDict(object):
         cassandra.DriverException, cassandra.RequestExecutionException
     )
 
-    def __init__(self, namespace, url=None, keyspace=None, column_family=None,
+    def __init__(self, namespace, url=None, keyspace=None, column_family=None, trace=False,
                  **params):
         if not keyspace:
             raise MissingCacheParameter("keyspace is required")
@@ -108,14 +111,15 @@ class _CassandraBackedDict(object):
 
         self._tries = int(params.pop('tries', 1))
 
-        cluster = self.__connect_to_cluster(url, params)
+        # Use a ddtrace-d connection if instructed to
+        cluster = self.__connect_to_cluster(url, params, trace=trace)
         self.__session = cluster.connect(self.__keyspace_cql_safe)
         self.__ensure_table()
         self.__prepare_statements()
         # This 10s default matches the driver's default.
         self.__session.default_timeout = int(params.get('query_timeout', 10))
 
-    def __connect_to_cluster(self, urls, params):
+    def __connect_to_cluster(self, urls, params, trace=False):
         cluster_params = {}
 
         # If the config specifies a hostname which resolves to multiple
@@ -148,7 +152,11 @@ class _CassandraBackedDict(object):
         log.info(
             "Connecting to cassandra cluster with params %s", cluster_params
         )
-        return Cluster(**cluster_params)
+
+        if trace:
+            return get_traced_cassandra(tracer, service="beaker")(**cluster_params)
+        else:
+            return Cluster(**cluster_params)
 
     def __resolve_hostnames(self, hostnames):
         """Resolves a list of hostnames into a list of IP addresses using DNS."""

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='beaker_extensions',
       zip_safe=False,
       install_requires=[],
       extras_require={
-          'cassandra_cql': ['cassandra-driver>=3.1.0','ddtrace==0.3.4'],  # 3.1.0 added result iterators
+          'cassandra_cql': ['cassandra-driver>=3.1.0','ddtrace>=0.3.4'],  # 3.1.0 added result iterators
           'testsuite': [TESTS_REQUIRE]
       },
       test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.2.0+dd.16'
+version = '0.2.0+dd.17'
 
 TESTS_REQUIRE = ['nose']
 
@@ -21,7 +21,7 @@ setup(name='beaker_extensions',
       zip_safe=False,
       install_requires=[],
       extras_require={
-          'cassandra_cql': ['cassandra-driver>=3.1.0'],  # 3.1.0 added result iterators
+          'cassandra_cql': ['cassandra-driver>=3.1.0','ddtrace==0.3.4'],  # 3.1.0 added result iterators
           'testsuite': [TESTS_REQUIRE]
       },
       test_suite='nose.collector',


### PR DESCRIPTION
Add an option to `CassandraCqlManager` to trace queries with [ddtrace](https://github.com/Datadog/dd-trace-py)