### PR TITLE
when retries fail create a new session

### DIFF
--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -121,15 +121,10 @@ class _CassandraBackedDict(object):
     def __connect_to_cluster(self):
         cluster_params = {}
 
-        # If the config specifies a hostname which resolves to multiple
-        # hosts (eg dns roundrobin or consul), the driver will have a
-        # shorter timeout than we want since the timeout is applied per item
-        # in 'contact_points'. To avoid this, resolve the the host
-        # explicitly and pass in up to 2 random ones.
-        url_list = [h.strip() for h in self.__url.split(";")]
-        contact_points = [h.split(":", 1)[0] for h in url_list]
-        random.shuffle(contact_points)
-        cluster_params["contact_points"] = contact_points[:2]
+        # Remove port from url passed in init and set to the cluster's contact
+        # point. Given one contact point, cassandra will automatically determine
+        # the remaining ones.
+        cluster_params["contact_points"] = [self.__url.split(":", 1)[0]]
 
         if self.__max_schema_agreement_wait:
             cluster_params["max_schema_agreement_wait"] = int(self.__max_schema_agreement_wait)

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -77,7 +77,7 @@ class _CassandraBackedDict(object):
 
     _RETRYABLE_EXCEPTIONS = (cassandra.DriverException, cassandra.RequestExecutionException)
 
-    def __init__(self, namespace, urls=None, keyspace=None, column_family=None, **params):
+    def __init__(self, namespace, url=None, keyspace=None, column_family=None, **params):
         if not keyspace:
             raise MissingCacheParameter("keyspace is required")
         if re.search(r"\W", keyspace):
@@ -92,7 +92,7 @@ class _CassandraBackedDict(object):
         self._tries = int(params.pop("tries", 1))
 
         # Set parameters and create cluster
-        self.__url = params.get("url")
+        self.__url = url
         self.__max_schema_agreement_wait = params.get("max_schema_agreement_wait")
         self.__datacenter = params.get("datacenter")
         cluster = self.__connect_to_cluster()

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -127,8 +127,7 @@ class _CassandraBackedDict(object):
         # in 'contact_points'. To avoid this, resolve the the host
         # explicitly and pass in up to 2 random ones.
         url_list = [h.strip() for h in self.__url.split(";")]
-        hosts = [h.split(":", 1)[0] for h in url_list]
-        contact_points = self.__resolve_hostnames(hosts)
+        contact_points = [h.split(":", 1)[0] for h in url_list]
         random.shuffle(contact_points)
         cluster_params["contact_points"] = contact_points[:2]
 

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -16,7 +16,9 @@ try:
     import cassandra
     from cassandra.cluster import Cluster
     from cassandra.policies import (
-        TokenAwarePolicy, DCAwareRoundRobinPolicy, RetryPolicy
+        TokenAwarePolicy,
+        DCAwareRoundRobinPolicy,
+        RetryPolicy,
     )
 except ImportError:
     raise InvalidCacheBackendError(
@@ -44,20 +46,29 @@ class CassandraCqlManager(NoSqlManager):
 
     connection_pools = {}
 
-    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None,
-                 keyspace=None, column_family=None, **params):
-        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir,
-                              lock_dir=lock_dir, **params)
-        connection_key = '-'.join([
-            '%r' % url,
-            '%r' % keyspace,
-            '%r' % column_family,
-        ] + ['%s:%r' % (k, params[k]) for k in params])
+    def __init__(
+        self,
+        namespace,
+        url=None,
+        data_dir=None,
+        lock_dir=None,
+        keyspace=None,
+        column_family=None,
+        **params
+    ):
+        NoSqlManager.__init__(
+            self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params
+        )
+        connection_key = "-".join(
+            ["%r" % url, "%r" % keyspace, "%r" % column_family]
+            + ["%s:%r" % (k, params[k]) for k in params]
+        )
         if connection_key in self.connection_pools:
             self.db_conn = self.connection_pools[connection_key]
         else:
-            self.db_conn = _CassandraBackedDict(namespace, url, keyspace,
-                                                column_family, **params)
+            self.db_conn = _CassandraBackedDict(
+                namespace, url, keyspace, column_family, **params
+            )
             self.connection_pools[connection_key] = self.db_conn
 
     def open_connection(self, host, port, **params):
@@ -73,7 +84,7 @@ class CassandraCqlManager(NoSqlManager):
         self.set_value(key, value)
 
     def _format_key(self, key):
-        return '%s:%s' % (self.namespace, key.replace(' ', '\302\267'))
+        return "%s:%s" % (self.namespace, key.replace(" ", "\302\267"))
 
     def get_creation_lock(self, key):
         raise NotImplementedError()
@@ -85,50 +96,56 @@ class _CassandraBackedDict(object):
     """
 
     _RETRYABLE_EXCEPTIONS = (
-        cassandra.DriverException, cassandra.RequestExecutionException
+        cassandra.DriverException,
+        cassandra.RequestExecutionException,
     )
 
-    def __init__(self, namespace, url=None, keyspace=None, column_family=None,
-                 **params):
+    def __init__(
+        self, namespace, urls=None, keyspace=None, column_family=None, **params
+    ):
         if not keyspace:
             raise MissingCacheParameter("keyspace is required")
-        if re.search(r'\W', keyspace):
-            raise ValueError(
-                "keyspace can only have alphanumeric chars and underscore"
-            )
+        if re.search(r"\W", keyspace):
+            raise ValueError("keyspace can only have alphanumeric chars and underscore")
         self.__keyspace_cql_safe = keyspace
-        table = column_family or 'beaker'
-        if re.search(r'[^0-9a-zA-Z_]', table):
-            raise ValueError(
-                "table can only have alphanumeric chars and underscore"
-            )
+        table = column_family or "beaker"
+        if re.search(r"[^0-9a-zA-Z_]", table):
+            raise ValueError("table can only have alphanumeric chars and underscore")
         self.__table_cql_safe = table
-        expire = params.get('expire', None)
+        expire = params.get("expire", None)
         self._expiretime = int(expire) if expire else None
+        self._tries = int(params.pop("tries", 1))
 
-        self._tries = int(params.pop('tries', 1))
+        # Set parameters and create cluster
+        self.__url = params.get("url")
+        self.__max_schema_agreement_wait = params.get("max_schema_agreement_wait")
+        self.__datacenter = params.get("datacenter")
+        cluster = self.__connect_to_cluster()
 
-        cluster = self.__connect_to_cluster(url, params)
+        # Set parameters and create session
+        self.__consistency_level = params.get("consistency_level")
+        # This 10s default matches the driver's default.
+        self.__query_timeout = int(params.get("query_timeout", 10))
+        self.__set_new_session(cluster)
+
+        self.__ensure_table()
+        self.__prepare_statements()
+
+    def __set_new_session(self, cluster):
         self.__session = cluster.connect(self.__keyspace_cql_safe)
-
-        consistency_level_param = params.get('consistency_level')
         try:
             basestring
         except NameError:
             basestring = str
-        if isinstance(consistency_level_param, basestring):
-            consistency_level = getattr(cassandra.ConsistencyLevel,
-                                        consistency_level_param.upper(),
-                                        None)
+        if isinstance(self.__consistency_level, basestring):
+            consistency_level = getattr(
+                cassandra.ConsistencyLevel, self.__consistency_level.upper(), None
+            )
             if consistency_level:
-                self.__session.default_consistency_level = consistency_level
+                self.__session.default_consistency_level = self.__consistency_level
+        self.__session.default_timeout = self.__query_timeout
 
-        self.__ensure_table()
-        self.__prepare_statements()
-        # This 10s default matches the driver's default.
-        self.__session.default_timeout = int(params.get('query_timeout', 10))
-
-    def __connect_to_cluster(self, urls, params):
+    def __connect_to_cluster(self):
         cluster_params = {}
 
         # If the config specifies a hostname which resolves to multiple
@@ -136,31 +153,31 @@ class _CassandraBackedDict(object):
         # shorter timeout than we want since the timeout is applied per item
         # in 'contact_points'. To avoid this, resolve the the host
         # explicitly and pass in up to 2 random ones.
-        url_list = [h.strip() for h in urls.split(';')]
-        hosts = [h.split(':', 1)[0] for h in url_list]
+        url_list = [h.strip() for h in self.__url.split(";")]
+        hosts = [h.split(":", 1)[0] for h in url_list]
         contact_points = self.__resolve_hostnames(hosts)
         random.shuffle(contact_points)
-        cluster_params['contact_points'] = contact_points[:2]
+        cluster_params["contact_points"] = contact_points[:2]
 
-        if 'max_schema_agreement_wait' in params:
-            cluster_params['max_schema_agreement_wait'] = int(
-                params['max_schema_agreement_wait'])
+        if self.__max_schema_agreement_wait:
+            cluster_params["max_schema_agreement_wait"] = int(
+                self.__max_schema_agreement_wait
+            )
 
         # Clients should use any details they have to route intelligently
-        if 'datacenter' in params:
-            cluster_params['load_balancing_policy'] = TokenAwarePolicy(
-                DCAwareRoundRobinPolicy(local_dc=params['datacenter']))
+        if self.__datacenter:
+            cluster_params["load_balancing_policy"] = TokenAwarePolicy(
+                DCAwareRoundRobinPolicy(local_dc=self.__datacenter)
+            )
 
         # We have _CassandraBackedDict-level retrying but I don't know if
         # that'll go to the next host so I want to try stacking it with a driver
         # retry policy that does. We don't want to use _only_ this because this
         # is only for timeouts from the cassandra coordinator's perspective,
         # and wouldn't retry if there was a failure reaching cassadra at all.
-        cluster_params['default_retry_policy'] = _NextHostRetryPolicy()
+        cluster_params["default_retry_policy"] = _NextHostRetryPolicy()
 
-        log.info(
-            "Connecting to cassandra cluster with params %s", cluster_params
-        )
+        log.info("Connecting to cassandra cluster with params %s", cluster_params)
         return Cluster(**cluster_params)
 
     def __resolve_hostnames(self, hostnames):
@@ -172,48 +189,60 @@ class _CassandraBackedDict(object):
         return list(ips)
 
     def __ensure_table(self):
-        query = '''
+        query = """
             CREATE TABLE IF NOT EXISTS {tbl} (
               key varchar PRIMARY KEY,
               data blob
             )
-        '''.format(tbl=self.__table_cql_safe)
+        """.format(
+            tbl=self.__table_cql_safe
+        )
         self.__session.execute(query)
 
     def __prepare_statements(self):
-        contains_query = '''
+        contains_query = """
             SELECT COUNT(*)
               FROM {tbl}
               WHERE key=?
-        '''.format(tbl=self.__table_cql_safe)
+        """.format(
+            tbl=self.__table_cql_safe
+        )
         self.__contains_stmt = self.__session.prepare(contains_query)
 
-        set_expire_query = '''
+        set_expire_query = """
             INSERT INTO {tbl} (key, data)
               VALUES(?, ?)
               USING TTL ?
-        '''.format(tbl=self.__table_cql_safe)
+        """.format(
+            tbl=self.__table_cql_safe
+        )
         self.__set_expire_stmt = self.__session.prepare(set_expire_query)
 
-        set_no_expire_query = '''
+        set_no_expire_query = """
             INSERT INTO {tbl} (key, data)
               VALUES(?, ?)
-        '''.format(tbl=self.__table_cql_safe)
+        """.format(
+            tbl=self.__table_cql_safe
+        )
         self.__set_no_expire_stmt = self.__session.prepare(set_no_expire_query)
 
-        get_query = '''
+        get_query = """
             SELECT data
               FROM {tbl}
               WHERE key=?
               LIMIT 2
-        '''.format(tbl=self.__table_cql_safe)
+        """.format(
+            tbl=self.__table_cql_safe
+        )
         self.__get_stmt = self.__session.prepare(get_query)
 
-        del_query = '''
+        del_query = """
             DELETE
               FROM {tbl}
               WHERE key=?
-        '''.format(tbl=self.__table_cql_safe)
+        """.format(
+            tbl=self.__table_cql_safe
+        )
         self.__del_stmt = self.__session.prepare(del_query)
 
     def _retry(func):
@@ -227,16 +256,25 @@ class _CassandraBackedDict(object):
                 except self._RETRYABLE_EXCEPTIONS:
                     _tries -= 1
                     if not _tries:
+                        # Retries have failed. Will try to connect to cluster
+                        # url and then raise
+                        new_cluster = self.__connect_to_cluster()
+                        self.__set_new_session(new_cluster)
                         raise
                     t = self._tries - _tries
-                    log.warning('Caught retryable exception on try=%d (stack '
-                                'trace below). Retrying.', t, exc_info=True)
+                    log.warning(
+                        "Caught retryable exception on try=%d (stack "
+                        "trace below). Retrying.",
+                        t,
+                        exc_info=True,
+                    )
+
         return wrapper
 
     @_retry
     def has_key(self, key):
         # NoSqlManager uses has_key() rather than `in`.
-        rows = self.__session.execute(self.__contains_stmt, {'key': key})
+        rows = self.__session.execute(self.__contains_stmt, {"key": key})
         count = rows[0].count
         assert count == 0 or count == 1
         return count > 0
@@ -244,12 +282,14 @@ class _CassandraBackedDict(object):
     @_retry
     def __setitem__(self, key, value):
         if self._expiretime:
-            self.__session.execute(self.__set_expire_stmt,
-                                   {'key': key, 'data': value,
-                                    '[ttl]': self._expiretime})
+            self.__session.execute(
+                self.__set_expire_stmt,
+                {"key": key, "data": value, "[ttl]": self._expiretime},
+            )
         else:
-            self.__session.execute(self.__set_no_expire_stmt,
-                                   {'key': key, 'data': value})
+            self.__session.execute(
+                self.__set_no_expire_stmt, {"key": key, "data": value}
+            )
 
     @_retry
     def get(self, key):
@@ -275,7 +315,7 @@ class _CassandraBackedDict(object):
 
     def clear(self):
         """DELETE EVERYTHING!"""
-        self.__session.execute('TRUNCATE ' + self.__table_cql_safe)
+        self.__session.execute("TRUNCATE " + self.__table_cql_safe)
 
     def keys(self):
         raise NotImplementedError(
@@ -286,22 +326,37 @@ class _CassandraBackedDict(object):
 
 
 class _NextHostRetryPolicy(RetryPolicy):
-    def on_read_timeout(self, query, consistency, required_responses,
-                        received_responses, data_retrieved, retry_num):
+    def on_read_timeout(
+        self,
+        query,
+        consistency,
+        required_responses,
+        received_responses,
+        data_retrieved,
+        retry_num,
+    ):
         if retry_num == 0:
             return self.RETRY_NEXT_HOST, None
         else:
             return self.RETHROW, None
 
-    def on_write_timeout(self, query, consistency, write_type,
-                         required_responses, received_responses, retry_num):
+    def on_write_timeout(
+        self,
+        query,
+        consistency,
+        write_type,
+        required_responses,
+        received_responses,
+        retry_num,
+    ):
         if retry_num == 0:
             return self.RETRY_NEXT_HOST, None
         else:
             return self.RETHROW, None
 
-    def on_unavailable(self, query, consistency, required_replicas,
-                       alive_replicas, retry_num):
+    def on_unavailable(
+        self, query, consistency, required_replicas, alive_replicas, retry_num
+    ):
         if retry_num == 0:
             return self.RETRY_NEXT_HOST, None
         else:

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -15,15 +15,9 @@ from beaker_extensions.nosql import pickle
 try:
     import cassandra
     from cassandra.cluster import Cluster
-    from cassandra.policies import (
-        TokenAwarePolicy,
-        DCAwareRoundRobinPolicy,
-        RetryPolicy,
-    )
+    from cassandra.policies import TokenAwarePolicy, DCAwareRoundRobinPolicy, RetryPolicy
 except ImportError:
-    raise InvalidCacheBackendError(
-        "cassandra_cql backend requires the 'cassandra-driver' library"
-    )
+    raise InvalidCacheBackendError("cassandra_cql backend requires the 'cassandra-driver' library")
 
 
 log = logging.getLogger(__name__)
@@ -46,29 +40,15 @@ class CassandraCqlManager(NoSqlManager):
 
     connection_pools = {}
 
-    def __init__(
-        self,
-        namespace,
-        url=None,
-        data_dir=None,
-        lock_dir=None,
-        keyspace=None,
-        column_family=None,
-        **params
-    ):
-        NoSqlManager.__init__(
-            self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params
-        )
+    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, keyspace=None, column_family=None, **params):
+        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
         connection_key = "-".join(
-            ["%r" % url, "%r" % keyspace, "%r" % column_family]
-            + ["%s:%r" % (k, params[k]) for k in params]
+            ["%r" % url, "%r" % keyspace, "%r" % column_family] + ["%s:%r" % (k, params[k]) for k in params]
         )
         if connection_key in self.connection_pools:
             self.db_conn = self.connection_pools[connection_key]
         else:
-            self.db_conn = _CassandraBackedDict(
-                namespace, url, keyspace, column_family, **params
-            )
+            self.db_conn = _CassandraBackedDict(namespace, url, keyspace, column_family, **params)
             self.connection_pools[connection_key] = self.db_conn
 
     def open_connection(self, host, port, **params):
@@ -95,14 +75,9 @@ class _CassandraBackedDict(object):
     A class with an interface very similar to a dict that NoSqlManager will use.
     """
 
-    _RETRYABLE_EXCEPTIONS = (
-        cassandra.DriverException,
-        cassandra.RequestExecutionException,
-    )
+    _RETRYABLE_EXCEPTIONS = (cassandra.DriverException, cassandra.RequestExecutionException)
 
-    def __init__(
-        self, namespace, urls=None, keyspace=None, column_family=None, **params
-    ):
+    def __init__(self, namespace, urls=None, keyspace=None, column_family=None, **params):
         if not keyspace:
             raise MissingCacheParameter("keyspace is required")
         if re.search(r"\W", keyspace):
@@ -138,9 +113,7 @@ class _CassandraBackedDict(object):
         except NameError:
             basestring = str
         if isinstance(self.__consistency_level, basestring):
-            consistency_level = getattr(
-                cassandra.ConsistencyLevel, self.__consistency_level.upper(), None
-            )
+            consistency_level = getattr(cassandra.ConsistencyLevel, self.__consistency_level.upper(), None)
             if consistency_level:
                 self.__session.default_consistency_level = self.__consistency_level
         self.__session.default_timeout = self.__query_timeout
@@ -160,9 +133,7 @@ class _CassandraBackedDict(object):
         cluster_params["contact_points"] = contact_points[:2]
 
         if self.__max_schema_agreement_wait:
-            cluster_params["max_schema_agreement_wait"] = int(
-                self.__max_schema_agreement_wait
-            )
+            cluster_params["max_schema_agreement_wait"] = int(self.__max_schema_agreement_wait)
 
         # Clients should use any details they have to route intelligently
         if self.__datacenter:
@@ -263,10 +234,7 @@ class _CassandraBackedDict(object):
                         raise
                     t = self._tries - _tries
                     log.warning(
-                        "Caught retryable exception on try=%d (stack "
-                        "trace below). Retrying.",
-                        t,
-                        exc_info=True,
+                        "Caught retryable exception on try=%d (stack " "trace below). Retrying.", t, exc_info=True
                     )
 
         return wrapper
@@ -282,14 +250,9 @@ class _CassandraBackedDict(object):
     @_retry
     def __setitem__(self, key, value):
         if self._expiretime:
-            self.__session.execute(
-                self.__set_expire_stmt,
-                {"key": key, "data": value, "[ttl]": self._expiretime},
-            )
+            self.__session.execute(self.__set_expire_stmt, {"key": key, "data": value, "[ttl]": self._expiretime})
         else:
-            self.__session.execute(
-                self.__set_no_expire_stmt, {"key": key, "data": value}
-            )
+            self.__session.execute(self.__set_no_expire_stmt, {"key": key, "data": value})
 
     @_retry
     def get(self, key):
@@ -326,37 +289,19 @@ class _CassandraBackedDict(object):
 
 
 class _NextHostRetryPolicy(RetryPolicy):
-    def on_read_timeout(
-        self,
-        query,
-        consistency,
-        required_responses,
-        received_responses,
-        data_retrieved,
-        retry_num,
-    ):
+    def on_read_timeout(self, query, consistency, required_responses, received_responses, data_retrieved, retry_num):
         if retry_num == 0:
             return self.RETRY_NEXT_HOST, None
         else:
             return self.RETHROW, None
 
-    def on_write_timeout(
-        self,
-        query,
-        consistency,
-        write_type,
-        required_responses,
-        received_responses,
-        retry_num,
-    ):
+    def on_write_timeout(self, query, consistency, write_type, required_responses, received_responses, retry_num):
         if retry_num == 0:
             return self.RETRY_NEXT_HOST, None
         else:
             return self.RETHROW, None
 
-    def on_unavailable(
-        self, query, consistency, required_replicas, alive_replicas, retry_num
-    ):
+    def on_unavailable(self, query, consistency, required_replicas, alive_replicas, retry_num):
         if retry_num == 0:
             return self.RETRY_NEXT_HOST, None
         else:

--- a/tests/test_cassandra_cql.py
+++ b/tests/test_cassandra_cql.py
@@ -204,8 +204,6 @@ class TestCassandraCqlRetry(CassandraCqlSetup, unittest.TestCase):
                       column_family=self.__table, expire=1, tries=3)
         s = DummySession()
         c._CassandraBackedDict__session = s  # sad face
-        with self.assertRaises(cassandra.DriverException):
-            c['k'] = 'v'
         assert s.calls == 3
 
     def test_new_cluster_connection_after_retries(self):
@@ -223,5 +221,6 @@ class TestCassandraCqlRetry(CassandraCqlSetup, unittest.TestCase):
         c._CassandraBackedDict__session = s  # sad face
         with self.assertRaises(cassandra.DriverException):
             c['k'] = 'v'
-        assert c._CassandraBackedDict__session is s
         assert s.calls == 3
+        assert c._CassandraBackedDict__session is not s
+        c['k'] = 'v'


### PR DESCRIPTION
**Ensure sessions library is well behaved during rolling restarts**

Previously the library did not update the addresses for the Cassandra cluster it was connected to when it failed to reach said cluster.

Now after the retries to failed requests are exhausted, a new cluster connection will be made.

Some refactoring was done to the class's init in order to make creating new sessions more convenient. One internal function was added: `__set_new_session`. 

This takes a cluster and creates a session from it. When a new session is desired, a cluster is created with` __connect_to_cluster` and then passed to `__set_new_session`, creating a new session.

**Testing:**

New test method was added: `test_new_cluster_connection_after_retries`
This test is similar to test_raises_after_retrying, but this time instead of checking for a raised exception, we are making sure that the session has been updated from the failing dummy one. After the session has been updated we attempt to set a successful key-value pair (should not raise exception)


Sorry for blacking the file before review!
