### PR TITLE
remove dns resolution

### DIFF
--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -119,8 +119,7 @@ class _CassandraBackedDict(object):
         # in 'contact_points'. To avoid this, resolve the the host
         # explicitly and pass in up to 2 random ones.
         url_list = [h.strip() for h in urls.split(";")]
-        hosts = [h.split(":", 1)[0] for h in url_list]
-        contact_points = self.__resolve_hostnames(hosts)
+        contact_points = [h.split(":", 1)[0] for h in url_list]
         random.shuffle(contact_points)
         cluster_params["contact_points"] = contact_points[:2]
 


### PR DESCRIPTION
Removing dns host resolution from the library so that the lib will use the url we send in instead of the resolved host ips.