### PR TITLE
[PY3-23] ♻️ Ensure py2/3 compliance

### DIFF
--- a/beaker_extensions/_compat.py
+++ b/beaker_extensions/_compat.py
@@ -1,6 +1,8 @@
 # Excerpted from beaker._compat.py.
 
+from __future__ import absolute_import
 import sys
+import six
 
 # True if we are running on Python 2.
 PY2 = sys.version_info[0] == 2
@@ -13,7 +15,7 @@ if not PY2:  # pragma: no cover
 
 
 else:
-    unicode_text = unicode
+    unicode_text = six.text_type
     byte_string = str
 
     def u_(s):
@@ -22,4 +24,4 @@ else:
 
         if not isinstance(s, byte_string):
             s = str(s)
-        return unicode(s, "utf-8")
+        return six.text_type(s, "utf-8")

--- a/beaker_extensions/cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from functools import wraps
 import logging
 import random
@@ -8,6 +9,7 @@ from beaker.exceptions import InvalidCacheBackendError, MissingCacheParameter
 
 from beaker_extensions.nosql import Container
 from beaker_extensions.nosql import NoSqlManager
+import six
 
 try:
     import cassandra
@@ -98,11 +100,7 @@ class _CassandraBackedDict(object):
         self.__session = cluster.connect(self.__keyspace_cql_safe)
 
         consistency_level_param = params.get("consistency_level")
-        try:
-            basestring
-        except NameError:
-            basestring = str
-        if isinstance(consistency_level_param, basestring):
+        if isinstance(consistency_level_param, six.string_types):
             consistency_level = getattr(cassandra.ConsistencyLevel, consistency_level_param.upper(), None)
             if consistency_level:
                 self.__session.default_consistency_level = consistency_level
@@ -258,11 +256,11 @@ class _CassandraBackedDict(object):
         # https://datastax-oss.atlassian.net/browse/PYTHON-463
         rows = iter(self.__session.execute(self.__get_stmt, [key]))
         try:
-            res = rows.next()
+            res = next(rows)
         except StopIteration:
             return None
         try:
-            rows.next()
+            next(rows)
             assert False, "get {} found more than 1 row".format(key)
         except StopIteration:
             pass

--- a/beaker_extensions/cassandra_thrift.py
+++ b/beaker_extensions/cassandra_thrift.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 from beaker.exceptions import InvalidCacheBackendError, MissingCacheParameter
 

--- a/beaker_extensions/dynomite_.py
+++ b/beaker_extensions/dynomite_.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 from beaker.exceptions import InvalidCacheBackendError
 

--- a/beaker_extensions/nosql.py
+++ b/beaker_extensions/nosql.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json
 import logging
 
@@ -7,7 +8,7 @@ from beaker.util import verify_directory
 from beaker.exceptions import MissingCacheParameter
 
 try:
-    import cPickle as pickle
+    import six.moves.cPickle as pickle
 except Exception:
     import pickle
 

--- a/beaker_extensions/pytyrant.py
+++ b/beaker_extensions/pytyrant.py
@@ -23,10 +23,15 @@ for the raw Tyrant protocol::
     >>> del t['__test_key__']
 
 """
+from __future__ import absolute_import
 import math
 import socket
 import struct
 import UserDict
+
+from six.moves import map
+from six.moves import range
+from six import iterkeys, iteritems
 
 __version__ = "1.1.17"
 
@@ -217,7 +222,7 @@ class PyTyrant(object, UserDict.DictMixin):
             raise KeyError(key)
 
     def __iter__(self):
-        return self.iterkeys()
+        return iterkeys(self)
 
     def iterkeys(self):
         self.t.iterinit()
@@ -228,7 +233,7 @@ class PyTyrant(object, UserDict.DictMixin):
             pass
 
     def keys(self):
-        return list(self.iterkeys())
+        return list(iterkeys(self))
 
     def __len__(self):
         return self.t.rnum()
@@ -241,7 +246,7 @@ class PyTyrant(object, UserDict.DictMixin):
         if other is None:
             pass
         elif hasattr(other, "iteritems"):
-            self.multi_set(other.iteritems())
+            self.multi_set(iteritems(other))
         elif hasattr(other, "keys"):
             self.multi_set([(k, other[k]) for k in other.keys()])
         else:
@@ -266,8 +271,8 @@ class PyTyrant(object, UserDict.DictMixin):
                 raise KeyError("Missing a result, unusable response in 1.1.10")
             return rval
         # 1.1.11 protocol returns interleaved key, value list
-        d = dict((rval[i], rval[i + 1]) for i in xrange(0, len(rval), 2))
-        return map(d.get, keys)
+        d = dict((rval[i], rval[i + 1]) for i in range(0, len(rval), 2))
+        return list(map(d.get, keys))
 
     def multi_set(self, items, no_update_log=False):
         opts = no_update_log and RDBMONOULOG or 0
@@ -374,7 +379,7 @@ class Tyrant(object):
         socksend(self.sock, _tN(C.mget, klst))
         socksuccess(self.sock)
         numrecs = socklen(self.sock)
-        for i in xrange(numrecs):
+        for i in range(numrecs):
             k, v = sockstrpair(self.sock)
             yield k, v
 
@@ -407,7 +412,7 @@ class Tyrant(object):
         socksend(self.sock, _t1M(C.fwmkeys, prefix, maxkeys))
         socksuccess(self.sock)
         numkeys = socklen(self.sock)
-        for i in xrange(numkeys):
+        for i in range(numkeys):
             yield sockstr(self.sock)
 
     def fwmkeys(self, prefix, maxkeys):
@@ -495,7 +500,7 @@ class Tyrant(object):
             socksuccess(self.sock)
         finally:
             numrecs = socklen(self.sock)
-        for i in xrange(numrecs):
+        for i in range(numrecs):
             yield sockstr(self.sock)
 
     def misc(self, func, opts, args):

--- a/beaker_extensions/redis_.py
+++ b/beaker_extensions/redis_.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json
 import logging
 from beaker.exceptions import InvalidCacheBackendError

--- a/beaker_extensions/riak_.py
+++ b/beaker_extensions/riak_.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 from beaker.exceptions import InvalidCacheBackendError
 

--- a/beaker_extensions/ringo.py
+++ b/beaker_extensions/ringo.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 from beaker.exceptions import InvalidCacheBackendError
 
@@ -6,7 +7,7 @@ from beaker_extensions.nosql import NoSqlManager
 from beaker_extensions.nosql import pickle
 
 try:
-    from ringogw import Ringo
+    from .ringogw import Ringo
 except ImportError:
     raise InvalidCacheBackendError("Ringo cache backend requires the 'ringogw' library")
 

--- a/beaker_extensions/ringogw.py
+++ b/beaker_extensions/ringogw.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import cjson
 import pycurl
 import cStringIO
@@ -111,12 +113,12 @@ class Ringo:
             curl.perform()
         except pycurl.error as x:
             if verbose:
-                print("Pycurl.error:", x)
+                print(("Pycurl.error:", x))
             return x
 
         code = curl.getinfo(curl.HTTP_CODE)
         if verbose:
-            print("Request took %.2fms" % (curl.getinfo(curl.TOTAL_TIME) * 1000.0))
+            print(("Request took %.2fms" % (curl.getinfo(curl.TOTAL_TIME) * 1000.0)))
 
         # Request timeout
         if code == 408 and retries > 0:

--- a/beaker_extensions/tests/common.py
+++ b/beaker_extensions/tests/common.py
@@ -193,7 +193,7 @@ class CommonMethodMixin(object):
         assert "err" in self.cache
         got = self.cache.get_value("err")
         assert type(got) == Exception
-        assert got.message == "Too much partying"
+        assert got.args[0] == "Too much partying"
 
         # via dict interface
         assert "key2" not in self.cache
@@ -201,4 +201,4 @@ class CommonMethodMixin(object):
         assert "key2" in self.cache
         got2 = self.cache.get_value("key2")
         assert type(got2) == Exception
-        assert got2.message == "Too much partying"
+        assert got2.args[0] == "Too much partying"

--- a/beaker_extensions/tests/common.py
+++ b/beaker_extensions/tests/common.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+from __future__ import absolute_import
 import time
 
 from beaker_extensions._compat import u_
@@ -122,7 +123,7 @@ class CommonMethodMixin(object):
         assert x == 16
 
         cache.remove_value("test")
-        assert not cache.has_key("test")
+        assert "test" not in cache
         x = cache.get_value("test", createfunc=lambda: 20, expiretime=2)
         assert x == 20
 

--- a/beaker_extensions/tests/test_cassandra_cql.py
+++ b/beaker_extensions/tests/test_cassandra_cql.py
@@ -112,7 +112,7 @@ class CassandraTestOverrides(object):
                 serializer="json",
             )
         except ValueError as error:
-            if "keyspace can only have" not in error.message:
+            if "keyspace can only have" not in error.args[0]:
                 raise
 
     def test_invalid_table(self):
@@ -126,7 +126,7 @@ class CassandraTestOverrides(object):
                 serializer="json",
             )
         except ValueError as error:
-            if "table can only have" not in error.message:
+            if "table can only have" not in error.args[0]:
                 raise
 
 

--- a/beaker_extensions/tests/test_cassandra_cql.py
+++ b/beaker_extensions/tests/test_cassandra_cql.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from time import sleep
 import unittest
 
@@ -9,7 +10,7 @@ from beaker.cache import Cache
 import cassandra
 
 from beaker_extensions.cassandra_cql import CassandraCqlManager, _CassandraBackedDict
-from common import CommonMethodMixin
+from .common import CommonMethodMixin
 
 
 class CassandraCqlSetup(object):

--- a/beaker_extensions/tests/test_redis.py
+++ b/beaker_extensions/tests/test_redis.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 from nose.plugins.attrib import attr
@@ -5,7 +6,7 @@ from nose.tools import nottest
 
 from beaker.cache import Cache
 
-from common import CommonMethodMixin
+from .common import CommonMethodMixin
 
 
 class RedisTestOverrides(object):

--- a/beaker_extensions/tyrant_.py
+++ b/beaker_extensions/tyrant_.py
@@ -1,4 +1,5 @@
 # Courtesy of: http://www.jackhsu.com/2009/05/27/pylons-with-tokyo-cabinet-beaker-sessions
+from __future__ import absolute_import
 import logging
 from beaker.exceptions import InvalidCacheBackendError
 
@@ -7,7 +8,7 @@ from beaker_extensions.nosql import NoSqlManager
 from beaker_extensions.nosql import pickle
 
 try:
-    from pytyrant import PyTyrant
+    from .pytyrant import PyTyrant
 except ImportError:
     raise InvalidCacheBackendError("PyTyrant cache backend requires the 'pytyrant' library")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
-nose
-cassandra_cql
-cassandra-driver
-redis
+cassandra-cql==0.9.0
+cassandra-driver==3.24.0
+click==7.1.2
+cql==1.4.0
+funcsigs==1.0.2
+geomet==0.2.1.post1
+nose==1.3.7
+redis==3.5.3
+six==1.15.0
+thrift==0.13.0
 
 git+https://github.com/DataDog/beaker@1.9.0+dd.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-cassandra-cql==0.9.0
-cassandra-driver==3.24.0
-click==7.1.2
-cql==1.4.0
-funcsigs==1.0.2
-geomet==0.2.1.post1
-nose==1.3.7
-redis==3.5.3
-six==1.15.0
-thrift==0.13.0
+cassandra-cql>=0.9.0
+cassandra-driver>=3.24.0
+click>=7.1.2
+cql>=1.4.0
+funcsigs>=1.0.2
+geomet>=0.2.1.post1
+nose>=1.3.7
+redis>=3.5.3
+six>=1.15.0
+thrift>=0.13.0
 
 git+https://github.com/DataDog/beaker@1.9.0+dd.25

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "0.2.0+dd.27"
+version = "0.3.0+dd.1"
 
 TESTS_REQUIRE = ["nose"]
 
@@ -8,7 +8,11 @@ setup(
     name="beaker_extensions",
     version=version,
     description="Beaker extensions for additional back-end stores.",
-    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+    ],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
     keywords="",
     author="Didip Kerabat",
     author_email="didipk@gmail.com",


### PR DESCRIPTION
# What does this PR do?

- Updated the `requirements.txt` file ;
- Applied `python-modernize` to ensure python2 + python3 compliance ;
- Fixed a few bugs on python3, mostly related to confusion between `bytes` and `string` ;
- Bumped the version from `0.2.0+dd.26` to `0.3.0+dd.1`

# Motivation

https://datadoghq.atlassian.net/browse/PY3-23

# Testing

You can run a `redis` container + a `cassandra` container locally and run `python setup.py test` in python2 and python3 environments. That's what I did and got all tests to pass ✅ 

