### PR TITLE
PY3-23: Simplify deps (remove CQL and Thrift)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 nose>=1.3.7
 cassandra-driver>=3.24.0
+redis>=3.5.3
 six>=1.15.0
 
 git+https://github.com/DataDog/beaker@1.9.0+dd.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-cassandra-cql>=0.9.0
-cassandra-driver>=3.24.0
-click>=7.1.2
-cql>=1.4.0
-funcsigs>=1.0.2
-geomet>=0.2.1.post1
 nose>=1.3.7
-redis>=3.5.3
+cassandra-driver>=3.24.0
 six>=1.15.0
-thrift>=0.13.0
 
 git+https://github.com/DataDog/beaker@1.9.0+dd.25

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "0.3.0+dd.1"
+version = "0.3.0+dd.2"
 
 TESTS_REQUIRE = ["nose"]
 


### PR DESCRIPTION
We don't need the CQL dependencies in here; this simplifies things.