### PR TITLE
Add statsd metrics for cassandra cluster responses and connection state

### DIFF
--- a/beaker_extensions/cassandra_cql/__init__.py
+++ b/beaker_extensions/cassandra_cql/__init__.py
@@ -1,0 +1,4 @@
+from beaker_extensions.cassandra_cql.manager import CassandraCqlManager
+
+
+__all__ = ["CassandraCqlManager"]

--- a/beaker_extensions/cassandra_cql/manager.py
+++ b/beaker_extensions/cassandra_cql/manager.py
@@ -1,17 +1,15 @@
-from __future__ import absolute_import
-
-import logging
 import random
 import re
 import socket
-from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, cast, overload
-
 import six
-from beaker.exceptions import InvalidCacheBackendError, MissingCacheParameter
-from datadog import statsd
+from beaker_extensions.nosql import NoSqlManager
+from beaker_extensions.cassandra_cql.utils import retry
+from beaker_extensions.cassandra_cql.retry_policy import AlwaysRetryNextHostPolicy
+from beaker.exceptions import MissingCacheParameter
+from beaker.exceptions import InvalidCacheBackendError
 
-from beaker_extensions.nosql import Container, NoSqlManager
+import logging
+
 
 try:
     import cassandra
@@ -19,98 +17,12 @@ try:
     from cassandra.cluster import Cluster
     from cassandra.policies import (
         DCAwareRoundRobinPolicy,
-        RetryPolicy,
         TokenAwarePolicy,
     )
 except ImportError:
-    raise InvalidCacheBackendError(
-        "cassandra_cql backend requires the 'cassandra-driver' library"
-    )
-
-if TYPE_CHECKING:
-    from typing import Optional, Type, Union
-
+    raise InvalidCacheBackendError("cassandra_cql backend requires the 'cassandra-driver' library")
 
 log = logging.getLogger(__name__)
-
-
-class SupportsRetry(Protocol):
-    _tries = 0  # type: int
-    _RETRYABLE_EXCEPTIONS = tuple()  # type: tuple[Type[Exception], ...]
-
-
-F = TypeVar("F", bound=Callable[..., Any])
-Decorator = Callable[[F], F]
-
-# This signature is for setting the tries override
-@overload
-def _retry(
-    func=None,  # type: None
-    tries=None,  # type: Optional[int]
-):  # type: (...) -> Decorator
-    pass
-
-
-# This signature is for wrapping a function
-@overload
-def _retry(
-    func,  # type: F
-):  # type: (...) -> F
-    pass
-
-
-def _retry(
-    func=None,  # type: Optional[F]
-    tries=None,  # type: Optional[int]
-):  # type: (...) -> Union[F, Decorator[F]]
-    """_retry will call the decorated function a number of times if a registered Exception is raised
-
-    Args:
-        tries (int, optional): The number of times to try the function. Defaults to the Class attribute `_tries`.
-    """
-    if func is None:
-        return cast(Decorator[F], partial(_retry, tries=tries))
-
-    @wraps(func)
-    def wrapper(
-        self,  # type: SupportsRetry
-        *args,
-        **kwargs
-    ):
-        retry_count = tries or self._tries
-        _tries = retry_count
-        while _tries:
-            try:
-                return func(self, *args, **kwargs)
-            except self._RETRYABLE_EXCEPTIONS:
-                _tries -= 1
-                if not _tries:
-                    statsd.increment(
-                        "dd.cassandra_cql.retry",
-                        tags=[
-                            "function:{}".format(func.__name__),
-                            "status:error",
-                            "retry_count:{}".format(_tries),
-                        ],
-                    )
-                    raise
-                t = retry_count - _tries
-                statsd.increment(
-                    "dd.cassandra_cql.retry",
-                    tags=[
-                        "function:{}".format(func.__name__),
-                        "status:retry",
-                        "retry_count:{}".format(_tries),
-                    ],
-                )
-                log.warning(
-                    "Caught retryable exception on try=%d (stack "
-                    "trace below). Retrying.",
-                    t,
-                    exc_info=True,
-                )
-
-    return cast(F, wrapper)
 
 
 class CassandraCqlManager(NoSqlManager):
@@ -134,29 +46,15 @@ class CassandraCqlManager(NoSqlManager):
 
     connection_pools = {}
 
-    def __init__(
-        self,
-        namespace,
-        url=None,
-        data_dir=None,
-        lock_dir=None,
-        keyspace=None,
-        column_family=None,
-        **params
-    ):
-        NoSqlManager.__init__(
-            self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params
-        )
+    def __init__(self, namespace, url=None, data_dir=None, lock_dir=None, keyspace=None, column_family=None, **params):
+        NoSqlManager.__init__(self, namespace, url=url, data_dir=data_dir, lock_dir=lock_dir, **params)
         connection_key = "-".join(
-            ["%r" % url, "%r" % keyspace, "%r" % column_family]
-            + ["%s:%r" % (k, params[k]) for k in params]
+            ["%r" % url, "%r" % keyspace, "%r" % column_family] + ["%s:%r" % (k, params[k]) for k in params]
         )
         if connection_key in self.connection_pools:
             self.db_conn = self.connection_pools[connection_key]
         else:
-            self.db_conn = _CassandraBackedDict(
-                namespace, url, keyspace, column_family, **params
-            )
+            self.db_conn = _CassandraBackedDict(namespace, url, keyspace, column_family, **params)
             self.connection_pools[connection_key] = self.db_conn
 
     def open_connection(self, host, port, **params):
@@ -190,9 +88,7 @@ class _CassandraBackedDict(object):
         cassandra.RequestExecutionException,
     )
 
-    def __init__(
-        self, namespace, url=None, keyspace=None, column_family=None, **params
-    ):
+    def __init__(self, namespace, url=None, keyspace=None, column_family=None, **params):
         if not keyspace:
             raise MissingCacheParameter("keyspace is required")
         if re.search(r"\W", keyspace):
@@ -212,9 +108,7 @@ class _CassandraBackedDict(object):
 
         consistency_level_param = params.get("consistency_level")
         if isinstance(consistency_level_param, six.string_types):
-            consistency_level = getattr(
-                cassandra.ConsistencyLevel, consistency_level_param.upper(), None
-            )
+            consistency_level = getattr(cassandra.ConsistencyLevel, consistency_level_param.upper(), None)
             if consistency_level:
                 self.__session.default_consistency_level = consistency_level
 
@@ -238,9 +132,7 @@ class _CassandraBackedDict(object):
         cluster_params["contact_points"] = contact_points[:2]
 
         if "max_schema_agreement_wait" in params:
-            cluster_params["max_schema_agreement_wait"] = int(
-                params["max_schema_agreement_wait"]
-            )
+            cluster_params["max_schema_agreement_wait"] = int(params["max_schema_agreement_wait"])
 
         # Clients should use any details they have to route intelligently
         if "datacenter" in params:
@@ -258,14 +150,12 @@ class _CassandraBackedDict(object):
         # retry policy that does. We don't want to use _only_ this because this
         # is only for timeouts from the cassandra coordinator's perspective,
         # and wouldn't retry if there was a failure reaching cassandra at all.
-        cluster_params["default_retry_policy"] = _NextHostRetryPolicy()
+        cluster_params["default_retry_policy"] = AlwaysRetryNextHostPolicy()
 
         # If username and password is provided in the params
         # then include an auth provider when connecting to the cluster
         if "username" in params and "password" in params:
-            auth = PlainTextAuthProvider(
-                username=params["username"], password=params["password"]
-            )
+            auth = PlainTextAuthProvider(username=params["username"], password=params["password"])
             cluster_params["auth_provider"] = auth
 
         log.info("Connecting to cassandra cluster with params %s", cluster_params)
@@ -336,7 +226,7 @@ class _CassandraBackedDict(object):
         )
         self.__del_stmt = self.__session.prepare(del_query)
 
-    @_retry
+    @retry
     def has_key(self, key):
         # NoSqlManager uses has_key() rather than `in`.
         rows = self.__session.execute(self.__contains_stmt, {"key": key})
@@ -344,7 +234,7 @@ class _CassandraBackedDict(object):
         assert count == 0 or count == 1
         return count > 0
 
-    @_retry(tries=2)
+    @retry(tries=2)
     def __setitem__(self, key, value):
         data = value if isinstance(value, bytes) else value.encode()
         if self._expiretime:
@@ -353,11 +243,9 @@ class _CassandraBackedDict(object):
                 {"key": key, "data": data, "[ttl]": self._expiretime},
             )
         else:
-            self.__session.execute(
-                self.__set_no_expire_stmt, {"key": key, "data": data}
-            )
+            self.__session.execute(self.__set_no_expire_stmt, {"key": key, "data": data})
 
-    @_retry
+    @retry
     def get(self, key):
         # NoSqlManager uses get() rather than [].
         #
@@ -375,7 +263,7 @@ class _CassandraBackedDict(object):
             pass
         return res.data
 
-    @_retry
+    @retry
     def __delitem__(self, key):
         self.__session.execute(self.__del_stmt, [key])
 
@@ -389,45 +277,3 @@ class _CassandraBackedDict(object):
             "keys, not the keys used by the rest of this class' api. "
             "Regardless, it doesn't seem to be used so I'm not implementing it."
         )
-
-
-class _NextHostRetryPolicy(RetryPolicy):
-    def on_read_timeout(
-        self,
-        query,
-        consistency,
-        required_responses,
-        received_responses,
-        data_retrieved,
-        retry_num,
-    ):
-        if retry_num == 0:
-            return self.RETRY_NEXT_HOST, None
-        else:
-            return self.RETHROW, None
-
-    def on_write_timeout(
-        self,
-        query,
-        consistency,
-        write_type,
-        required_responses,
-        received_responses,
-        retry_num,
-    ):
-        if retry_num == 0:
-            return self.RETRY_NEXT_HOST, None
-        else:
-            return self.RETHROW, None
-
-    def on_unavailable(
-        self, query, consistency, required_replicas, alive_replicas, retry_num
-    ):
-        if retry_num == 0:
-            return self.RETRY_NEXT_HOST, None
-        else:
-            return self.RETHROW, None
-
-
-class CassandraCqlContainer(Container):
-    namespace_class = CassandraCqlManager

--- a/beaker_extensions/cassandra_cql/metrics.py
+++ b/beaker_extensions/cassandra_cql/metrics.py
@@ -1,0 +1,202 @@
+import logging
+from random import random
+from typing import TYPE_CHECKING, TypedDict, Protocol
+import weakref
+
+from datadog import statsd
+
+
+log = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from cassandra.cluster import Cluster
+    from typing import Text, Literal
+
+    class _StatsdService(Protocol):
+        def increment(
+            self,
+            metric,  # type: Text
+        ):
+            pass
+
+        def gauge(
+            self,
+            metric,  # type: Text
+            value,  # type: float
+        ):
+            pass
+
+        def distribution(
+            self,
+            metric,  # type: Text
+            value,  # type: float
+        ):
+            pass
+
+    ResponseStatus = Literal[
+        "connection_error",
+        "ignore",
+        "other_error",
+        "read_timeout",
+        "retry",
+        "unavailable",
+        "write_timeout",
+    ]
+
+
+class _RequestTimer(object):
+    def __init__(
+        self,
+        statsd,  # type: _StatsdService
+        metric,  # type: Text
+    ):
+        self._statsd = statsd
+        self._metric = metric
+
+    def addValue(
+        self,
+        value,  # type: float
+    ):
+        self._statsd.distribution(self._metric, value)
+
+
+class _SupportsMetrics(Protocol):
+    """A protocol representing all of the hooks exposed by cassandra.metrics.Metrics"""
+
+    @property
+    def request_timer(self):  # type: (...) -> _RequestTimer
+        return _RequestTimer(statsd, "")
+
+    def on_connection_error(self):
+        pass
+
+    def on_write_timeout(self):
+        pass
+
+    def on_read_timeout(self):
+        pass
+
+    def on_unavailable(self):
+        pass
+
+    def on_other_error(self):
+        pass
+
+    def on_ignore(self):
+        pass
+
+    def on_retry(self):
+        pass
+
+
+_ClusterStats = TypedDict("_ClusterStats", {"known_hosts": int, "connected_hosts": int, "open_connections": int})
+
+
+def _one_in_n(n=10000):
+    return random() < (1 / n)
+
+
+class StatsdMetrics:
+    """StatsdMetrics is intended to be a drop-in replacement for cassandra.metrics.Metrics for a Cluster instance."""
+
+    _STATS_PREFIX = "dd.cassandra_cql.cluster."
+
+    def __init__(
+        self,
+        cluster_proxy,  # type: weakref.ProxyType[Cluster]
+        stats_service=statsd,  # type: _StatsdService
+        is_lucky=_one_in_n,
+    ):
+        self._cluster_proxy = cluster_proxy
+        self._statsd = stats_service
+        self._request_timer = _RequestTimer(self._statsd, self._STATS_PREFIX + "query_latency.distribution")
+        self._is_lucky = is_lucky
+
+    @classmethod
+    def bind_ref(
+        cls,
+        cluster,  # type: Cluster
+    ):  # type: (...) -> _SupportsMetrics
+        instance = cls(weakref.proxy(cluster))
+        return instance
+
+    def _on_response(
+        self,
+        status,  # type: ResponseStatus
+    ):
+        try:
+            self._statsd.increment(self._STATS_PREFIX + "response." + status)
+        except Exception:
+            log.warn("Error occurred while submitting Cassandra response stats: ignoring", exc_info=True)
+
+    def on_connection_error(self):
+        """An unrecoverable error was hit when attempting to use a connection,
+        or the connection was already closed or defunct.
+        """
+        self._on_response("connection_error")
+
+    def on_ignore(self):
+        """A query failed and we're not retrying it or re-throwing the error,
+        we're just pretending that nothing happened.
+        """
+        self._on_response("ignore")
+
+    def on_other_error(self):
+        """Cluster is overloaded or still bootstrapping, or a truncate operation
+        failed, or some other server error occurred.
+        """
+        self._on_response("other_error")
+
+    def on_read_timeout(self):
+        """Cluster-defined read timeout has expired"""
+        self._on_response("read_timeout")
+
+    def on_retry(self):
+        """A query is being retried against the same or a new host"""
+        self._on_response("retry")
+
+    def on_unavailable(self):
+        """The required cluster members for a query a not available"""
+        self._on_response("unavailable")
+
+    def on_write_timeout(self):
+        """Cluster-defined write timeout has expired"""
+        self._on_response("write_timeout")
+
+    def _submit_cluster_gauges(self):
+        # NOTE: generating these stats don't often change, and they're relatively
+        # expensive to calculate given their value. For this reason we'll only
+        # bother to tabulate and submit them given some random sample.
+        if not self._is_lucky():
+            return
+
+        stats = self._generate_cluster_stats()
+        self._statsd.gauge(self._STATS_PREFIX + "num_known_hosts", stats["known_hosts"])
+        self._statsd.gauge(self._STATS_PREFIX + "num_connected_hosts", stats["connected_hosts"])
+        self._statsd.gauge(self._STATS_PREFIX + "num_open_connections", stats["open_connections"])
+
+    def _generate_cluster_stats(self):  # type: (...) -> _ClusterStats
+        known_hosts = len(self._cluster_proxy.metadata.all_hosts())
+        connected_hosts = set()
+        open_connections = 0
+        for session in self._cluster_proxy.sessions:
+            for host, pool in session._pools.items():
+                connected_hosts.add(host)
+                open_connections += pool.open_count
+
+        return _ClusterStats(
+            known_hosts=known_hosts, connected_hosts=len(connected_hosts), open_connections=open_connections
+        )
+
+    @property
+    def request_timer(self):
+        # NOTE: Accessing the request_timer represents the finalization of a query
+        # in the driver. We'll use this opportunity to submit statistics about our
+        # cluster state.
+        try:
+            self._submit_cluster_gauges()
+        except Exception:
+            log.warn("Error occurred while submitting Cassandra cluster stats: ignoring", exc_info=True)
+
+        return self._request_timer

--- a/beaker_extensions/cassandra_cql/retry_policy.py
+++ b/beaker_extensions/cassandra_cql/retry_policy.py
@@ -1,0 +1,44 @@
+from beaker.exceptions import InvalidCacheBackendError
+
+try:
+    from cassandra.policies import (
+        RetryPolicy,
+    )
+except ImportError:
+    raise InvalidCacheBackendError("cassandra_cql backend requires the 'cassandra-driver' library")
+
+
+class AlwaysRetryNextHostPolicy(RetryPolicy):
+    def on_read_timeout(
+        self,
+        query,
+        consistency,
+        required_responses,
+        received_responses,
+        data_retrieved,
+        retry_num,
+    ):
+        if retry_num == 0:
+            return self.RETRY_NEXT_HOST, None
+        else:
+            return self.RETHROW, None
+
+    def on_write_timeout(
+        self,
+        query,
+        consistency,
+        write_type,
+        required_responses,
+        received_responses,
+        retry_num,
+    ):
+        if retry_num == 0:
+            return self.RETRY_NEXT_HOST, None
+        else:
+            return self.RETHROW, None
+
+    def on_unavailable(self, query, consistency, required_replicas, alive_replicas, retry_num):
+        if retry_num == 0:
+            return self.RETRY_NEXT_HOST, None
+        else:
+            return self.RETHROW, None

--- a/beaker_extensions/cassandra_cql/tests/test_cassandra_cql.py
+++ b/beaker_extensions/cassandra_cql/tests/test_cassandra_cql.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
 import unittest
-from doctest import Example
 from time import sleep
-from typing import TYPE_CHECKING
 
 import beaker
 import cassandra
@@ -13,12 +11,8 @@ from nose.tools import nottest
 
 from beaker_extensions.cassandra_cql import CassandraCqlManager
 from beaker_extensions.cassandra_cql.manager import _CassandraBackedDict
-from beaker_extensions.cassandra_cql.utils import retry
 
-from .common import CommonMethodMixin
-
-if TYPE_CHECKING:
-    from typing import Literal, NoReturn, Optional, Type
+from ...tests.common import CommonMethodMixin
 
 
 class CassandraCqlSetup(object):
@@ -326,93 +320,3 @@ class TestCassandraCqlAuth(CassandraCqlSetup, unittest.TestCase):
         session = cm.db_conn._CassandraBackedDict__session
 
         assert session.default_timeout == timeout
-
-
-class ExampleException(Exception):
-    pass
-
-
-class OtherExampleException(Exception):
-    pass
-
-
-class UnhandledException(Exception):
-    pass
-
-
-class ExampleRetryable(object):
-    _tries = 2
-    _RETRYABLE_EXCEPTIONS = (ExampleException, OtherExampleException)
-
-    def __init__(self):
-        self.should_fail = True
-        self.fail_counter = None  # type: Optional[int]
-        self.call_counter = 0
-
-    @retry
-    def always_passes(self):  # type: () -> Literal[True]
-        self.call_counter += 1
-        return True
-
-    @retry
-    def always_fails(self, exception_class=ExampleException):  # type: (Type[Exception]) -> NoReturn
-        self.call_counter += 1
-        raise exception_class()
-
-    @retry
-    def alternate_fails(self):  # type: () -> Literal[True]
-        self.call_counter += 1
-        try:
-            if self.should_fail:
-                raise OtherExampleException()
-        finally:
-            self.should_fail = not self.should_fail
-        return True
-
-    @retry(tries=3)
-    def fail_countdown_custom(self, bad_runs):  # type: (int) -> Literal[True]
-        self.call_counter += 1
-        if self.fail_counter is None:
-            self.fail_counter = bad_runs
-        self.fail_counter -= 1
-        if self.fail_counter:
-            raise ExampleException()
-        return True
-
-
-@attr("cassandra_cql")
-class TestRetries(unittest.TestCase):
-    def setUp(self):
-        self.er = ExampleRetryable()
-
-    def test_normal_success(self):
-        x = self.er.always_passes()
-        self.assertEquals(self.er.call_counter, 1)
-
-    def test_normal_fail(self):
-        # Never succeeds
-        with self.assertRaises(ExampleException):
-            self.er.always_fails()
-        self.assertEquals(self.er.call_counter, 2)
-
-    def test_cant_retry(self):
-        # This exception is never retried
-        with self.assertRaises(UnhandledException):
-            self.er.always_fails(UnhandledException)
-        self.assertEquals(self.er.call_counter, 1)
-
-    def test_retries_eventually(self):
-        # Fails once, and then succeeds on the 2nd try
-        assert self.er.alternate_fails()
-        self.assertEquals(self.er.call_counter, 2)
-
-    def test_custom_retries_exceeded(self):
-        # custom override to try 3 times, but function will fail 4 times
-        with self.assertRaises(ExampleException):
-            self.er.fail_countdown_custom(4)
-        self.assertEquals(self.er.call_counter, 3)
-
-    def test_custom_retries_success(self):
-        # custom override to try 3 times, function succeeds on 3rd try
-        assert self.er.fail_countdown_custom(3)
-        self.assertEquals(self.er.call_counter, 3)

--- a/beaker_extensions/cassandra_cql/tests/test_metrics.py
+++ b/beaker_extensions/cassandra_cql/tests/test_metrics.py
@@ -1,0 +1,114 @@
+import weakref
+
+try:
+    from unittest.mock import Mock, call
+except ImportError:
+    from mock import Mock, call  # type: ignore
+
+from cassandra.cluster import Cluster
+
+from beaker_extensions.cassandra_cql.metrics import StatsdMetrics
+
+
+def get_test_instance():
+    statsd = Mock()
+    cluster = Mock()
+    cluster.metadata.all_hosts.return_value = []
+    cluster.sessions = []
+    metrics = StatsdMetrics(weakref.proxy(cluster), statsd)  # type: ignore
+    return metrics, statsd, cluster
+
+
+def assert_gauge_calls(mok, known_hosts=0, connected_hosts=0, open_connections=0):
+    mok.gauge.assert_has_calls(
+        [
+            call("dd.cassandra_cql.cluster.num_known_hosts", known_hosts),
+            call("dd.cassandra_cql.cluster.num_connected_hosts", connected_hosts),
+            call("dd.cassandra_cql.cluster.num_open_connections", open_connections),
+        ]
+    )
+
+
+class TestStatsdMetrics(object):
+    def test_instantiates_without_exploding(self):
+        assert StatsdMetrics(weakref.proxy(Cluster()))
+
+    def test_bind_ref_instantiates_without_exploding(self):
+        assert StatsdMetrics.bind_ref(Cluster())
+
+    def test_on_connection_error(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_connection_error()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.connection_error")
+
+    def test_on_ignore(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_ignore()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.ignore")
+
+    def test_on_other_error(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_other_error()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.other_error")
+
+    def test_on_read_timeout(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_read_timeout()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.read_timeout")
+
+    def test_on_retry(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_retry()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.retry")
+
+    def test_on_unavailable(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_unavailable()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.unavailable")
+
+    def test_on_write_timeout(self):
+        metrics, statsd, _ = get_test_instance()
+
+        metrics.on_write_timeout()
+
+        statsd.increment.assert_called_once_with("dd.cassandra_cql.cluster.response.write_timeout")
+
+    def test_request_timer(self):
+        metrics, statsd, _ = get_test_instance()
+        metrics._is_lucky = lambda: True  # type: ignore
+        value = 0.5
+
+        metrics.request_timer.addValue(value)
+
+        statsd.distribution.assert_called_once_with("dd.cassandra_cql.cluster.query_latency.distribution", value)
+        assert_gauge_calls(statsd)
+
+    def test_cluster_gauges(self):
+        class Pool(object):
+            open_count = 3
+
+        class Session(object):
+            _pools = {1: Pool(), 2: Pool()}
+
+        cluster = Cluster()
+        cluster.metadata._hosts = {1: "host_1", 2: "host_2"}  # type: ignore
+        cluster.sessions = [Session(), Session()]  # type: ignore
+
+        statsd = Mock()
+        metrics = StatsdMetrics(weakref.proxy(cluster), statsd, is_lucky=lambda: True)  # type: ignore
+
+        metrics._submit_cluster_gauges()
+
+        assert_gauge_calls(statsd, known_hosts=2, connected_hosts=2, open_connections=12)

--- a/beaker_extensions/cassandra_cql/tests/test_utils.py
+++ b/beaker_extensions/cassandra_cql/tests/test_utils.py
@@ -1,0 +1,100 @@
+from typing import TYPE_CHECKING
+import unittest
+
+from nose.plugins.attrib import attr
+
+from beaker_extensions.cassandra_cql.utils import retry
+
+
+if TYPE_CHECKING:
+    from typing import Literal, NoReturn, Optional, Type
+
+
+class ExampleException(Exception):
+    pass
+
+
+class OtherExampleException(Exception):
+    pass
+
+
+class UnhandledException(Exception):
+    pass
+
+
+class ExampleRetryable(object):
+    _tries = 2
+    _RETRYABLE_EXCEPTIONS = (ExampleException, OtherExampleException)
+
+    def __init__(self):
+        self.should_fail = True
+        self.fail_counter = None  # type: Optional[int]
+        self.call_counter = 0
+
+    @retry
+    def always_passes(self):  # type: () -> Literal[True]
+        self.call_counter += 1
+        return True
+
+    @retry
+    def always_fails(self, exception_class=ExampleException):  # type: (Type[Exception]) -> NoReturn
+        self.call_counter += 1
+        raise exception_class()
+
+    @retry
+    def alternate_fails(self):  # type: () -> Literal[True]
+        self.call_counter += 1
+        try:
+            if self.should_fail:
+                raise OtherExampleException()
+        finally:
+            self.should_fail = not self.should_fail
+        return True
+
+    @retry(tries=3)
+    def fail_countdown_custom(self, bad_runs):  # type: (int) -> Literal[True]
+        self.call_counter += 1
+        if self.fail_counter is None:
+            self.fail_counter = bad_runs
+        self.fail_counter -= 1
+        if self.fail_counter:
+            raise ExampleException()
+        return True
+
+
+@attr("cassandra_cql")
+class TestRetries(unittest.TestCase):
+    def setUp(self):
+        self.er = ExampleRetryable()
+
+    def test_normal_success(self):
+        x = self.er.always_passes()
+        self.assertEquals(self.er.call_counter, 1)
+
+    def test_normal_fail(self):
+        # Never succeeds
+        with self.assertRaises(ExampleException):
+            self.er.always_fails()
+        self.assertEquals(self.er.call_counter, 2)
+
+    def test_cant_retry(self):
+        # This exception is never retried
+        with self.assertRaises(UnhandledException):
+            self.er.always_fails(UnhandledException)
+        self.assertEquals(self.er.call_counter, 1)
+
+    def test_retries_eventually(self):
+        # Fails once, and then succeeds on the 2nd try
+        assert self.er.alternate_fails()
+        self.assertEquals(self.er.call_counter, 2)
+
+    def test_custom_retries_exceeded(self):
+        # custom override to try 3 times, but function will fail 4 times
+        with self.assertRaises(ExampleException):
+            self.er.fail_countdown_custom(4)
+        self.assertEquals(self.er.call_counter, 3)
+
+    def test_custom_retries_success(self):
+        # custom override to try 3 times, function succeeds on 3rd try
+        assert self.er.fail_countdown_custom(3)
+        self.assertEquals(self.er.call_counter, 3)

--- a/beaker_extensions/cassandra_cql/utils.py
+++ b/beaker_extensions/cassandra_cql/utils.py
@@ -1,0 +1,87 @@
+from functools import partial, wraps
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, cast, overload
+from datadog import statsd
+
+if TYPE_CHECKING:
+    from typing import Optional, Type, Union
+
+log = logging.getLogger(__name__)
+
+
+class SupportsRetry(Protocol):
+    _tries = 0  # type: int
+    _RETRYABLE_EXCEPTIONS = tuple()  # type: tuple[Type[Exception], ...]
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+Decorator = Callable[[F], F]
+
+# This signature is for setting the tries override
+@overload
+def retry(
+    func=None,  # type: None
+    tries=None,  # type: Optional[int]
+):  # type: (...) -> Decorator
+    pass
+
+
+# This signature is for wrapping a function
+@overload
+def retry(
+    func,  # type: F
+):  # type: (...) -> F
+    pass
+
+
+def retry(
+    func=None,  # type: Optional[F]
+    tries=None,  # type: Optional[int]
+):  # type: (...) -> Union[F, Decorator[F]]
+    """_retry will call the decorated function a number of times if a registered Exception is raised
+
+    Args:
+        tries (int, optional): The number of times to try the function. Defaults to the Class attribute `_tries`.
+    """
+    if func is None:
+        return cast(Decorator[F], partial(retry, tries=tries))
+
+    @wraps(func)
+    def wrapper(
+        self,  # type: SupportsRetry
+        *args,
+        **kwargs
+    ):
+        retry_count = tries or self._tries
+        _tries = retry_count
+        while _tries:
+            try:
+                return func(self, *args, **kwargs)
+            except self._RETRYABLE_EXCEPTIONS:
+                _tries -= 1
+                if not _tries:
+                    statsd.increment(
+                        "dd.cassandra_cql.retry",
+                        tags=[
+                            "function:{}".format(func.__name__),
+                            "status:error",
+                            "retry_count:{}".format(_tries),
+                        ],
+                    )
+                    raise
+                t = retry_count - _tries
+                statsd.increment(
+                    "dd.cassandra_cql.retry",
+                    tags=[
+                        "function:{}".format(func.__name__),
+                        "status:retry",
+                        "retry_count:{}".format(_tries),
+                    ],
+                )
+                log.warning(
+                    "Caught retryable exception on try=%d (stack " "trace below). Retrying.",
+                    t,
+                    exc_info=True,
+                )
+
+    return cast(F, wrapper)

--- a/beaker_extensions/cassandra_cql/utils.py
+++ b/beaker_extensions/cassandra_cql/utils.py
@@ -38,7 +38,7 @@ def retry(
     func=None,  # type: Optional[F]
     tries=None,  # type: Optional[int]
 ):  # type: (...) -> Union[F, Decorator[F]]
-    """_retry will call the decorated function a number of times if a registered Exception is raised
+    """retry will call the decorated function a number of times if a registered Exception is raised
 
     Args:
         tries (int, optional): The number of times to try the function. Defaults to the Class attribute `_tries`.

--- a/beaker_extensions/tests/test_cassandra_cql.py
+++ b/beaker_extensions/tests/test_cassandra_cql.py
@@ -11,11 +11,9 @@ from beaker.cache import Cache, clsmap
 from nose.plugins.attrib import attr
 from nose.tools import nottest
 
-from beaker_extensions.cassandra_cql import (
-    CassandraCqlManager,
-    _CassandraBackedDict,
-    _retry,
-)
+from beaker_extensions.cassandra_cql import CassandraCqlManager
+from beaker_extensions.cassandra_cql.manager import _CassandraBackedDict
+from beaker_extensions.cassandra_cql.utils import retry
 
 from .common import CommonMethodMixin
 
@@ -351,19 +349,17 @@ class ExampleRetryable(object):
         self.fail_counter = None  # type: Optional[int]
         self.call_counter = 0
 
-    @_retry
+    @retry
     def always_passes(self):  # type: () -> Literal[True]
         self.call_counter += 1
         return True
 
-    @_retry
-    def always_fails(
-        self, exception_class=ExampleException
-    ):  # type: (Type[Exception]) -> NoReturn
+    @retry
+    def always_fails(self, exception_class=ExampleException):  # type: (Type[Exception]) -> NoReturn
         self.call_counter += 1
         raise exception_class()
 
-    @_retry
+    @retry
     def alternate_fails(self):  # type: () -> Literal[True]
         self.call_counter += 1
         try:
@@ -373,7 +369,7 @@ class ExampleRetryable(object):
             self.should_fail = not self.should_fail
         return True
 
-    @_retry(tries=3)
+    @retry(tries=3)
     def fail_countdown_custom(self, bad_runs):  # type: (int) -> Literal[True]
         self.call_counter += 1
         if self.fail_counter is None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 version = "0.3.0+dd.5"
 
-TESTS_REQUIRE = ["nose"]
+TESTS_REQUIRE = ["nose", "mock==2.0.0"]
 
 setup(
     name="beaker_extensions",


### PR DESCRIPTION
Passing `cluster_metrics_enabled=True` when instantiating the `CassandraCqlManager` (e.g. [here](https://github.com/DataDog/dogweb/blob/c8ac945db7fa802f7aa69fec6f3c6594b0782ea1/dogweb/lib/beaker_wrapper.py#L28)) will now configure a statsd publisher to report on query errors, response latency distributions, and cluster state.

TODOs: 
- [ ] assign version
- [ ] evaluate in staging